### PR TITLE
remove ineffective slice which slows down demux significantly

### DIFF
--- a/usm.js
+++ b/usm.js
@@ -181,7 +181,6 @@ var CRID = /** @class */ (function () {
                 case 0x56465340: // @SFV
                     if (type)
                         break;
-                    data.slice(ftell + off + 8);
                     p = new Uint8Array(data, ftell + off + 8, len - off - pad);
                     v_size += p.byteLength;
                     if (async)

--- a/usm.ts
+++ b/usm.ts
@@ -138,7 +138,6 @@ class CRID {
                     break;
                 case 0x56465340: // @SFV
                     if (type) break;
-                    data.slice(ftell + off + 8, )
                     p = new Uint8Array(data, ftell + off + 8, len - off - pad);
                     v_size += p.byteLength;
                     if (async) v_trunks_a.push(this.maskVideoAsync(p));


### PR DESCRIPTION
before: `demux took 27293`

after :`demux took 821`